### PR TITLE
Improve login UX with error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ npm run dev
 
 Access `<http://localhost:5173>`.
 
-- `/login` – email magic‑link sign‑in
+- `/login` – email magic‑link sign‑in (check your inbox after submitting)
 - `/hunt` – player dashboard
 - `/admin` – admin dashboard (role‑gated client‑side + RLS‑gated backend)
 
@@ -215,6 +215,7 @@ Access `<http://localhost:5173>`.
 | Magic‑link email not received | Verify Auth SMTP configuration or use OTP debug link in Supabase dashboard |
 | Photos 0 bytes                | Check Storage bucket rules and MIME type on upload                         |
 | RLS denies admin update       | Ensure `app_metadata.role` = `admin` and your JWT includes it              |
+| 500 error on login            | Verify `.env` contains valid Supabase keys and your Redirect URLs are allowed |
 
 ---
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,11 +4,21 @@ import { supabase } from '../supabaseClient';
 export default function Login() {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
 
   async function handleLogin(e) {
     e.preventDefault();
-    const { error } = await supabase.auth.signInWithOtp({ email });
-    if (!error) setSent(true);
+    setErrorMsg('');
+    try {
+      const { error } = await supabase.auth.signInWithOtp({ email });
+      if (error) {
+        setErrorMsg(error.message || 'Login failed');
+      } else {
+        setSent(true);
+      }
+    } catch (err) {
+      setErrorMsg('Server error. Check configuration and network.');
+    }
   }
 
   return (
@@ -27,6 +37,7 @@ export default function Login() {
             className="border p-2"
           />
           <button className="bg-blue-500 text-white p-2">Send Magic Link</button>
+          {errorMsg && <p className="text-red-600">{errorMsg}</p>}
         </form>
       )}
     </div>


### PR DESCRIPTION
## Summary
- display authentication errors on the login page
- clarify instructions for login in the README
- add troubleshooting note for login 500 errors

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8d1d5248323b59bcabbb0d09e8f