### PR TITLE
Fix login session handling

### DIFF
--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -7,12 +7,25 @@ export default function Admin() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const session = supabase.auth.session ? supabase.auth.session() : null;
-    setUser(session?.user || null);
-    setLoading(false);
-    supabase.auth.onAuthStateChange((_event, session) => {
+    let subscription;
+    async function loadSession() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setUser(session?.user || null);
+      setLoading(false);
+    }
+    loadSession();
+
+    const {
+      data: { subscription: sub },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user || null);
     });
+    subscription = sub;
+    return () => {
+      subscription?.unsubscribe();
+    };
   }, []);
 
   if (loading) return null;

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -7,11 +7,24 @@ export default function Hunt() {
   const [challenges, setChallenges] = useState([]);
 
   useEffect(() => {
-    const session = supabase.auth.session ? supabase.auth.session() : null;
-    setUser(session?.user || null);
-    supabase.auth.onAuthStateChange((_event, session) => {
+    let subscription;
+    async function loadSession() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setUser(session?.user || null);
+    }
+    loadSession();
+
+    const {
+      data: { subscription: sub },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user || null);
     });
+    subscription = sub;
+    return () => {
+      subscription?.unsubscribe();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,10 +1,32 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { supabase } from '../supabaseClient';
+import { useNavigate } from 'react-router-dom';
 
 export default function Login() {
   const [email, setEmail] = useState('');
   const [sent, setSent] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let subscription;
+    async function checkSession() {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (session) navigate('/hunt');
+    }
+    checkSession();
+    const {
+      data: { subscription: sub },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session) navigate('/hunt');
+    });
+    subscription = sub;
+    return () => {
+      subscription?.unsubscribe();
+    };
+  }, [navigate]);
 
   async function handleLogin(e) {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- update login page to redirect when already logged in
- use `supabase.auth.getSession` and subscribe to auth changes in pages

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685eda53a5108323a808750bf802dafd