### PR TITLE
Improve login page with register option and pirate theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Treasure Hunt MVP</title>
+    <link href="https://fonts.googleapis.com/css2?family=Pirata+One&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,9 @@
+body {
+  font-family: 'Pirata One', cursive;
+  background: linear-gradient(to bottom, #f9f4e7, #f5d9a4);
+  min-height: 100vh;
+}
+
+input, button {
+  font-family: inherit;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import './index.css';
 import Login from './pages/Login';
 import Hunt from './pages/Hunt';
 import Admin from './pages/Admin';

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -28,13 +28,15 @@ export default function Login() {
     };
   }, [navigate]);
 
-  async function handleLogin(e) {
-    e.preventDefault();
+  async function handleAuth(type) {
     setErrorMsg('');
     try {
-      const { error } = await supabase.auth.signInWithOtp({ email });
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: { shouldCreateUser: type === 'register' },
+      });
       if (error) {
-        setErrorMsg(error.message || 'Login failed');
+        setErrorMsg(error.message || 'Authentication failed');
       } else {
         setSent(true);
       }
@@ -44,23 +46,38 @@ export default function Login() {
   }
 
   return (
-    <div className="p-4 max-w-md mx-auto">
-      <h1 className="text-xl mb-4">Login</h1>
+    <div className="p-4 max-w-md mx-auto text-center">
+      <h1 className="text-3xl mb-4">Welcome, matey!</h1>
       {sent ? (
         <p>Check your email for a magic link.</p>
       ) : (
-        <form onSubmit={handleLogin} className="flex flex-col gap-2">
+        <div className="flex flex-col gap-4">
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
             required
-            className="border p-2"
+            className="border p-2 rounded"
           />
-          <button className="bg-blue-500 text-white p-2">Send Magic Link</button>
+          <div className="flex justify-center gap-4">
+            <button
+              type="button"
+              onClick={() => handleAuth('login')}
+              className="bg-blue-600 text-white px-4 py-2 rounded"
+            >
+              Login
+            </button>
+            <button
+              type="button"
+              onClick={() => handleAuth('register')}
+              className="bg-green-600 text-white px-4 py-2 rounded"
+            >
+              Register
+            </button>
+          </div>
           {errorMsg && <p className="text-red-600">{errorMsg}</p>}
-        </form>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add Google font and Tailwind CDN
- import global stylesheet
- create pirate-themed CSS styles
- update login page with Login/Register buttons

## Testing
- `npm test --silent` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_685edc1ff2888323b51a8073cdb7a317