### PR TITLE
Switch to password auth and admin whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a minimal MVP implementation located in the src folder.
 
 ## 1 Features
 
-- **Email magic‑link authentication** for players and admin
+- **Email/password authentication** with browser password-manager prompts
 - **Role‑based access control** enforced by Supabase Row Level Security
 - **Image uploads** stored privately in Supabase Storage
 - **Real‑time updates**: players see status changes instantly
@@ -135,9 +135,9 @@ Repeat analogous policies for `coins`.
 npm run dev
 ```
 
-Access `<http://localhost:5173>`.
+- Access `<http://localhost:5173>`.
 
-- `/login` – email magic‑link sign‑in (check your inbox after submitting)
+- `/login` – email/password sign-in
 - `/hunt` – player dashboard
 - `/admin` – admin dashboard (role‑gated client‑side + RLS‑gated backend)
 
@@ -184,7 +184,7 @@ Access `<http://localhost:5173>`.
 
 ## 9 Player Workflow
 
-1. Sign in via magic link.
+1. Sign in with your email and password.
 2. Earliest unlocked challenge shows an **Upload** input.
 3. After upload, card turns yellow (pending). When admin approves, card turns green and the next challenge unlocks.
 

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import AdminTable from '../components/AdminTable';
+import { Navigate } from 'react-router-dom';
 
 export default function Admin() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+  const ADMIN_WHITELIST = ['mdziedzic97@gmail.com'];
 
   useEffect(() => {
     let subscription;
@@ -30,6 +32,7 @@ export default function Admin() {
 
   if (loading) return null;
   if (!user) return <p className="p-4">Please log in first.</p>;
+  if (!ADMIN_WHITELIST.includes(user.email)) return <Navigate to="/hunt" replace />;
 
   return (
     <div className="p-4">

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -1,10 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import UploadPhoto from '../components/UploadPhoto';
+import { useNavigate } from 'react-router-dom';
 
 export default function Hunt() {
   const [user, setUser] = useState(null);
   const [challenges, setChallenges] = useState([]);
+  const navigate = useNavigate();
+
+  const ADMIN_WHITELIST = ['mdziedzic97@gmail.com'];
 
   useEffect(() => {
     let subscription;
@@ -45,6 +49,14 @@ export default function Hunt() {
 
   return (
     <div className="p-4 flex flex-col gap-4">
+      {ADMIN_WHITELIST.includes(user.email) && (
+        <button
+          onClick={() => navigate('/admin')}
+          className="bg-purple-600 text-white px-3 py-1 rounded self-start"
+        >
+          Go to Admin Panel
+        </button>
+      )}
       {challenges.map((c) => (
         <div key={c.id} className="border p-2">
           <h2 className="font-bold">{c.title}</h2>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,7 +4,9 @@ import { useNavigate } from 'react-router-dom';
 
 export default function Login() {
   const [email, setEmail] = useState('');
-  const [sent, setSent] = useState(false);
+  const [password, setPassword] = useState('');
+  const [mode, setMode] = useState('login'); // or 'register'
+  const [message, setMessage] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
   const navigate = useNavigate();
 
@@ -28,17 +30,46 @@ export default function Login() {
     };
   }, [navigate]);
 
-  async function handleAuth(type) {
+  async function storeCredentials() {
+    if (window.PasswordCredential) {
+      try {
+        await navigator.credentials.store(
+          new window.PasswordCredential({ id: email, password })
+        );
+      } catch (_) {
+        /* ignore */
+      }
+    }
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
     setErrorMsg('');
+    setMessage('');
+
     try {
-      const { error } = await supabase.auth.signInWithOtp({
-        email,
-        options: { shouldCreateUser: type === 'register' },
-      });
-      if (error) {
-        setErrorMsg(error.message || 'Authentication failed');
+      if (mode === 'register') {
+        const { error } = await supabase.auth.signUp({
+          email,
+          password,
+        });
+        if (error) {
+          setErrorMsg(error.message || 'Registration failed');
+        } else {
+          await storeCredentials();
+          setMessage('Check your email to confirm your account.');
+        }
       } else {
-        setSent(true);
+        const { error } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+        if (error) {
+          setErrorMsg(error.message || 'Authentication failed');
+        } else {
+          await storeCredentials();
+          navigate('/hunt');
+        }
       }
     } catch (err) {
       setErrorMsg('Server error. Check configuration and network.');
@@ -48,36 +79,48 @@ export default function Login() {
   return (
     <div className="p-4 max-w-md mx-auto text-center">
       <h1 className="text-3xl mb-4">Welcome, matey!</h1>
-      {sent ? (
-        <p>Check your email for a magic link.</p>
+      {message ? (
+        <p>{message}</p>
       ) : (
-        <div className="flex flex-col gap-4">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
             required
+            autoComplete="username"
+            className="border p-2 rounded"
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="password"
+            required
+            autoComplete={mode === 'register' ? 'new-password' : 'current-password'}
             className="border p-2 rounded"
           />
           <div className="flex justify-center gap-4">
             <button
-              type="button"
-              onClick={() => handleAuth('login')}
+              type="submit"
               className="bg-blue-600 text-white px-4 py-2 rounded"
             >
-              Login
+              {mode === 'login' ? 'Login' : 'Register'}
             </button>
             <button
               type="button"
-              onClick={() => handleAuth('register')}
-              className="bg-green-600 text-white px-4 py-2 rounded"
+              onClick={() => {
+                setMode(mode === 'login' ? 'register' : 'login');
+                setErrorMsg('');
+              }}
+              className="underline"
             >
-              Register
+              {mode === 'login' ? 'Need an account?' : 'Have an account?'}
             </button>
           </div>
           {errorMsg && <p className="text-red-600">{errorMsg}</p>}
-        </div>
+        </form>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- implement email/password registration and login
- prompt to save credentials via the browser password manager
- show admin panel link for whitelisted emails and gate `/admin`
- update README to describe new auth flow

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edf367ffc832393eae7c3bacd3f49