### PR TITLE
Handle existing user signup error

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -54,7 +54,14 @@ export default function Login() {
           password,
         });
         if (error) {
-          setErrorMsg(error.message || 'Registration failed');
+          if (
+            error.message &&
+            /already\s*registered|exists/i.test(error.message)
+          ) {
+            setErrorMsg('Account already exists. Please log in.');
+          } else {
+            setErrorMsg(error.message || 'Registration failed');
+          }
         } else {
           await storeCredentials();
           setMessage('Check your email to confirm your account.');


### PR DESCRIPTION
## Summary
- improve sign-up error handling
- show a friendly message when the email is already registered

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee3d59fdc8323a1dba0f9e819e7f8