### PR TITLE
Add admin challenge creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ Execute in *SQL Editor*:
 create table challenges (
   id uuid primary key default gen_random_uuid(),
   title text not null,
-  clue text,
+  description text,
+  hint text,
+  example_photo text,
+  active boolean default false,
   sort_order int not null
 );
 

--- a/src/components/CreateChallenge.jsx
+++ b/src/components/CreateChallenge.jsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function CreateChallenge() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [hint, setHint] = useState('');
+  const [examplePhoto, setExamplePhoto] = useState(null);
+  const [active, setActive] = useState(false);
+  const [status, setStatus] = useState('');
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setStatus('');
+
+    let examplePhotoPath = null;
+    if (examplePhoto) {
+      const filename = `${crypto.randomUUID()}`;
+      const { data, error } = await supabase.storage
+        .from('photos')
+        .upload(filename, examplePhoto);
+      if (error) {
+        setStatus('Photo upload failed');
+        return;
+      }
+      examplePhotoPath = data.path;
+    }
+
+    // fetch current max sort_order
+    const { data: existing } = await supabase
+      .from('challenges')
+      .select('sort_order')
+      .order('sort_order', { ascending: false })
+      .limit(1);
+    const nextOrder = existing && existing.length > 0 ? existing[0].sort_order + 1 : 1;
+
+    const { error } = await supabase.from('challenges').insert({
+      title,
+      description,
+      hint,
+      example_photo: examplePhotoPath,
+      active,
+      sort_order: nextOrder,
+    });
+    if (error) {
+      setStatus('Error creating challenge');
+    } else {
+      setTitle('');
+      setDescription('');
+      setHint('');
+      setExamplePhoto(null);
+      setActive(false);
+      setStatus('Challenge created');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 mb-4">
+      <h2 className="text-lg font-bold">Create Challenge</h2>
+      <input
+        type="text"
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        className="border p-1"
+        required
+      />
+      <textarea
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        className="border p-1"
+      />
+      <input
+        type="text"
+        placeholder="Hint"
+        value={hint}
+        onChange={(e) => setHint(e.target.value)}
+        className="border p-1"
+      />
+      <input
+        type="file"
+        onChange={(e) => setExamplePhoto(e.target.files[0])}
+      />
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={active}
+          onChange={(e) => setActive(e.target.checked)}
+        />
+        Active
+      </label>
+      <button className="bg-blue-600 text-white px-3 py-1">Create</button>
+      {status && <p>{status}</p>}
+    </form>
+  );
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import AdminTable from '../components/AdminTable';
+import CreateChallenge from '../components/CreateChallenge';
 import { Navigate } from 'react-router-dom';
 
 export default function Admin() {
@@ -37,6 +38,7 @@ export default function Admin() {
   return (
     <div className="p-4">
       <h1 className="text-xl mb-4">Admin Dashboard</h1>
+      <CreateChallenge />
       <AdminTable />
     </div>
   );

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -33,7 +33,11 @@ export default function Hunt() {
 
   useEffect(() => {
     async function loadChallenges() {
-      const { data } = await supabase.from('challenges').select('*').order('sort_order');
+      const { data } = await supabase
+        .from('challenges')
+        .select('*')
+        .eq('active', true)
+        .order('sort_order');
       setChallenges(data || []);
     }
     loadChallenges();
@@ -60,7 +64,15 @@ export default function Hunt() {
       {challenges.map((c) => (
         <div key={c.id} className="border p-2">
           <h2 className="font-bold">{c.title}</h2>
-          <p>{c.clue}</p>
+          {c.description && <p className="italic">{c.description}</p>}
+          {c.hint && <p>Hint: {c.hint}</p>}
+          {c.example_photo && (
+            <img
+              src={supabase.storage.from('photos').getPublicUrl(c.example_photo).data.publicUrl}
+              alt="example"
+              className="h-32 my-2"
+            />
+          )}
           <UploadPhoto challengeId={c.id} />
         </div>
       ))}


### PR DESCRIPTION
## Summary
- enable admins to add new challenges
- show active challenges with details on the Hunt page
- document new columns for challenges table

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee44fbe688323bf09da4cf123b677