### PR TITLE
Display created challenges

### DIFF
--- a/src/components/ChallengeList.jsx
+++ b/src/components/ChallengeList.jsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function ChallengeList() {
+  const [challenges, setChallenges] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      const { data } = await supabase
+        .from('challenges')
+        .select('*')
+        .order('sort_order');
+      setChallenges(data || []);
+    }
+    load();
+
+    const channel = supabase
+      .channel('challenges')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'challenges' }, load)
+      .subscribe();
+    return () => supabase.removeChannel(channel);
+  }, []);
+
+  return (
+    <table className="w-full border-collapse mb-4">
+      <thead>
+        <tr>
+          <th className="border p-2">Title</th>
+          <th className="border p-2">Active</th>
+        </tr>
+      </thead>
+      <tbody>
+        {challenges.map((c) => (
+          <tr key={c.id} className="border-t">
+            <td className="border p-2">{c.title}</td>
+            <td className="border p-2">{c.active ? 'Yes' : 'No'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import AdminTable from '../components/AdminTable';
 import CreateChallenge from '../components/CreateChallenge';
+import ChallengeList from '../components/ChallengeList';
 import { Navigate } from 'react-router-dom';
 
 export default function Admin() {
@@ -39,6 +40,7 @@ export default function Admin() {
     <div className="p-4">
       <h1 className="text-xl mb-4">Admin Dashboard</h1>
       <CreateChallenge />
+      <ChallengeList />
       <AdminTable />
     </div>
   );

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -41,6 +41,11 @@ export default function Hunt() {
       setChallenges(data || []);
     }
     loadChallenges();
+    const channel = supabase
+      .channel('challenges')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'challenges' }, loadChallenges)
+      .subscribe();
+    return () => supabase.removeChannel(channel);
   }, []);
 
   if (!user) {


### PR DESCRIPTION
## Summary
- list challenges on admin page via new `ChallengeList` component
- keep hunt page synced with only active challenges

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eea825df083239fd7837430cd4998