### PR TITLE
Fix submission uploads to include user_id

### DIFF
--- a/src/components/UploadPhoto.jsx
+++ b/src/components/UploadPhoto.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { supabase } from '../supabaseClient';
 
-export default function UploadPhoto({ challengeId }) {
+export default function UploadPhoto({ challengeId, userId }) {
   const [file, setFile] = useState(null);
   const [status, setStatus] = useState('');
 
@@ -16,6 +16,7 @@ export default function UploadPhoto({ challengeId }) {
     await supabase.from('submissions').insert({
       challenge_id: challengeId,
       photo_url: data.path,
+      user_id: userId,
     });
     setStatus('Submitted');
   }

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -94,7 +94,7 @@ export default function Hunt() {
               className="h-32 my-2"
             />
           )}
-          <UploadPhoto challengeId={c.id} />
+          <UploadPhoto challengeId={c.id} userId={user.id} />
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- include `userId` when inserting new submissions
- pass user id to `UploadPhoto` component

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef0080cf48323b11bccc8a689b1b9