### PR TITLE
Add submission status list

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ npm run dev
 1. Sign in with your email and password.
 2. Earliest unlocked challenge shows an **Upload** input.
 3. After upload, card turns yellow (pending). When admin approves, card turns green and the next challenge unlocks.
+4. View a table of your submitted photos with their current approval status below the challenges.
 
 ---
 

--- a/src/components/MySubmissions.jsx
+++ b/src/components/MySubmissions.jsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function MySubmissions({ userId }) {
+  const [subs, setSubs] = useState([]);
+  const [urls, setUrls] = useState({});
+
+  useEffect(() => {
+    if (!userId) return;
+    async function load() {
+      const { data } = await supabase
+        .from('submissions')
+        .select('id, status, photo_url, challenge_id(title), created_at')
+        .eq('user_id', userId)
+        .order('created_at', { ascending: false });
+      setSubs(data || []);
+      if (data) {
+        const u = {};
+        await Promise.all(
+          data.map(async (s) => {
+            if (s.photo_url) {
+              const { data: url } = await supabase
+                .storage
+                .from('photos')
+                .createSignedUrl(s.photo_url, 60 * 60);
+              u[s.id] = url?.signedUrl;
+            }
+          })
+        );
+        setUrls(u);
+      }
+    }
+    load();
+    const channel = supabase
+      .channel('user_subs')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'submissions', filter: `user_id=eq.${userId}` },
+        load
+      )
+      .subscribe();
+    return () => supabase.removeChannel(channel);
+  }, [userId]);
+
+  if (subs.length === 0) return null;
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-lg font-bold mb-2">My Submissions</h2>
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            <th className="border p-2">Challenge</th>
+            <th className="border p-2">Photo</th>
+            <th className="border p-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {subs.map((s) => (
+            <tr key={s.id} className="border-t">
+              <td className="border p-2">{s.challenge_id?.title || s.challenge_id}</td>
+              <td className="border p-2">
+                <img src={urls[s.id]} alt="submission" className="h-20" />
+              </td>
+              <td className="border p-2">{s.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import UploadPhoto from '../components/UploadPhoto';
+import MySubmissions from '../components/MySubmissions';
 import { useNavigate } from 'react-router-dom';
 
 export default function Hunt() {
@@ -97,6 +98,7 @@ export default function Hunt() {
           <UploadPhoto challengeId={c.id} userId={user.id} />
         </div>
       ))}
+      <MySubmissions userId={user.id} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow users to view their own photo submissions
- show an always updating list of submission photos with status
- document this new player-facing feature in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef19464508323a20e805a95b4b5f8