### PR TITLE
Enable full-screen photo viewer

### DIFF
--- a/src/components/AdminTable.jsx
+++ b/src/components/AdminTable.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
+import FullScreenImage from './FullScreenImage';
 
 export default function AdminTable() {
   const [submissions, setSubmissions] = useState([]);
   const [signedUrls, setSignedUrls] = useState({});
+  const [viewerUrl, setViewerUrl] = useState(null);
 
   useEffect(() => {
     const channel = supabase
@@ -48,7 +50,8 @@ export default function AdminTable() {
   }
 
   return (
-    <table className="w-full border-collapse">
+    <div className="relative">
+      <table className="w-full border-collapse">
       <thead>
         <tr>
           <th className="border p-2">Photo</th>
@@ -60,7 +63,12 @@ export default function AdminTable() {
         {submissions.map((s) => (
           <tr key={s.id} className="border-t">
             <td className="border p-2">
-              <img src={signedUrls[s.id]} alt="submission" className="h-20" />
+              <img
+                src={signedUrls[s.id]}
+                alt="submission"
+                className="h-20 cursor-pointer"
+                onClick={() => setViewerUrl(signedUrls[s.id])}
+              />
             </td>
             <td className="border p-2">{s.status}</td>
             <td className="border p-2">
@@ -70,6 +78,10 @@ export default function AdminTable() {
           </tr>
         ))}
       </tbody>
-    </table>
+      </table>
+      {viewerUrl && (
+        <FullScreenImage src={viewerUrl} alt="submission" onClose={() => setViewerUrl(null)} />
+      )}
+    </div>
   );
 }

--- a/src/components/FullScreenImage.jsx
+++ b/src/components/FullScreenImage.jsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+
+export default function FullScreenImage({ src, alt = '', onClose }) {
+  const getOrientation = () =>
+    window.innerHeight >= window.innerWidth ? 'portrait' : 'landscape';
+  const [orientation, setOrientation] = useState(getOrientation());
+
+  useEffect(() => {
+    const handler = () => setOrientation(getOrientation());
+    window.addEventListener('resize', handler);
+    window.addEventListener('orientationchange', handler);
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose?.();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('resize', handler);
+      window.removeEventListener('orientationchange', handler);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [onClose]);
+
+  const content = (
+    <div
+      className="fixed inset-0 z-50 bg-black bg-opacity-90 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <img
+        src={src}
+        alt={alt}
+        className={`object-contain ${
+          orientation === 'portrait' ? 'max-h-screen' : 'max-w-screen'
+        }`}
+      />
+    </div>
+  );
+
+  return ReactDOM.createPortal(content, document.body);
+}

--- a/src/components/UploadPhoto.jsx
+++ b/src/components/UploadPhoto.jsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react';
 import { supabase } from '../supabaseClient';
+import FullScreenImage from './FullScreenImage';
 
 export default function UploadPhoto({
   challengeId,
@@ -10,6 +11,7 @@ export default function UploadPhoto({
 }) {
   const inputRef = useRef(null);
   const [status, setStatus] = useState('');
+  const [showExample, setShowExample] = useState(false);
 
   async function handleFile(e) {
     const file = e.target.files?.[0];
@@ -32,12 +34,21 @@ export default function UploadPhoto({
   return (
     <div className="relative mt-2">
       {exampleUrl && (
-        <img
-          src={exampleUrl}
-          alt="example"
-          className="h-32 w-full object-cover rounded"
-          onClick={() => !submitted && inputRef.current.click()}
-        />
+        <>
+          <img
+            src={exampleUrl}
+            alt="example"
+            className="h-32 w-full object-cover rounded cursor-pointer"
+            onClick={() => setShowExample(true)}
+          />
+          {showExample && (
+            <FullScreenImage
+              src={exampleUrl}
+              alt="example"
+              onClose={() => setShowExample(false)}
+            />
+          )}
+        </>
       )}
       {!submitted && (
         <div

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import UploadPhoto from '../components/UploadPhoto';
+import FullScreenImage from '../components/FullScreenImage';
 import { useNavigate } from 'react-router-dom';
 
 export default function Hunt() {
@@ -11,6 +12,7 @@ export default function Hunt() {
   const [mySubs, setMySubs] = useState({});
   const [subUrls, setSubUrls] = useState({});
   const [expanded, setExpanded] = useState(null);
+  const [viewerUrl, setViewerUrl] = useState(null);
   const navigate = useNavigate();
 
   const ADMIN_WHITELIST = ['mdziedzic97@gmail.com'];
@@ -171,7 +173,8 @@ export default function Hunt() {
                           <img
                             src={subUrls[s.id]}
                             alt="submission"
-                            className="h-24 w-full object-cover rounded"
+                            className="h-24 w-full object-cover rounded cursor-pointer"
+                            onClick={() => setViewerUrl(subUrls[s.id])}
                           />
                           <span
                             className={`absolute bottom-1 right-1 text-xs px-1 rounded bg-white bg-opacity-70 ${
@@ -194,6 +197,13 @@ export default function Hunt() {
           </div>
         );
       })}
+      {viewerUrl && (
+        <FullScreenImage
+          src={viewerUrl}
+          alt="submission"
+          onClose={() => setViewerUrl(null)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- view photos in a full-screen overlay that adapts on orientation changes
- open example images and submission thumbnails in the viewer
- allow admins to view submissions full screen

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685efe2f07008323a0d77faf5fd5c3c0