### PR TITLE
Add fullscreen hint overlay

### DIFF
--- a/src/components/FullScreenHint.jsx
+++ b/src/components/FullScreenHint.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default function FullScreenHint({ text, onClose }) {
+  const content = (
+    <div
+      className="fixed inset-0 z-50 bg-black bg-opacity-90 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div className="bg-white p-4 rounded shadow max-w-xl mx-auto text-center whitespace-pre-wrap">
+        {text}
+      </div>
+    </div>
+  );
+  return ReactDOM.createPortal(content, document.body);
+}

--- a/src/components/UploadPhoto.jsx
+++ b/src/components/UploadPhoto.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react';
 import { supabase } from '../supabaseClient';
 import FullScreenImage from './FullScreenImage';
+import FullScreenHint from './FullScreenHint';
 
 export default function UploadPhoto({
   challengeId,
@@ -12,10 +13,12 @@ export default function UploadPhoto({
   onUploaded,
   title,
   description,
+  hint,
 }) {
   const inputRef = useRef(null);
   const [message, setMessage] = useState('');
   const [showExample, setShowExample] = useState(false);
+  const [showHint, setShowHint] = useState(false);
 
   async function handleFile(e) {
     const file = e.target.files?.[0];
@@ -50,7 +53,7 @@ export default function UploadPhoto({
             />
             {status && (
               <span
-                className={`absolute bottom-1 right-1 text-xs px-1 rounded bg-white bg-opacity-70 ${
+                className={`absolute bottom-1 left-1 text-xs px-1 rounded bg-white bg-opacity-70 ${
                   status === 'approved'
                     ? 'text-green-700'
                     : status === 'rejected'
@@ -61,6 +64,18 @@ export default function UploadPhoto({
                 {status}
               </span>
             )}
+            {hint && (
+              <button
+                className="absolute bottom-1 right-1 text-xs font-bold bg-white bg-opacity-70 rounded-full w-5 h-5 flex items-center justify-center"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowHint(true);
+                }}
+              >
+                ?
+              </button>
+            )}
+            {showHint && <FullScreenHint text={hint} onClose={() => setShowHint(false)} />}
             {showExample && (
               <FullScreenImage
                 src={photoSrc}

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -148,7 +148,6 @@ export default function Hunt() {
             </div>
             {expanded === c.id && (
               <div className="p-4 border-t bg-white rounded-b space-y-4">
-                {c.hint && <p className="text-sm text-gray-600">Hint: {c.hint}</p>}
                 <UploadPhoto
                   challengeId={c.id}
                   userId={user.id}
@@ -162,6 +161,7 @@ export default function Hunt() {
                   }
                   title={c.title}
                   description={c.description}
+                  hint={c.hint}
                   onUploaded={() =>
                     setChallengeStatus({
                       ...challengeStatus,


### PR DESCRIPTION
## Summary
- allow hints to be shown fullscreen on demand
- move status badge to bottom-left of polaroid
- pass hint through `UploadPhoto`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6dcd05108323aa276648f8f40bf6