### PR TITLE
Enable challenge activation toggle

### DIFF
--- a/src/components/ChallengeList.jsx
+++ b/src/components/ChallengeList.jsx
@@ -21,12 +21,20 @@ export default function ChallengeList() {
     return () => supabase.removeChannel(channel);
   }, []);
 
+  async function updateActive(id, active) {
+    await supabase.from('challenges').update({ active }).eq('id', id);
+    setChallenges(
+      challenges.map((c) => (c.id === id ? { ...c, active } : c))
+    );
+  }
+
   return (
     <table className="w-full border-collapse mb-4">
       <thead>
         <tr>
           <th className="border p-2">Title</th>
           <th className="border p-2">Active</th>
+          <th className="border p-2">Action</th>
         </tr>
       </thead>
       <tbody>
@@ -34,6 +42,14 @@ export default function ChallengeList() {
           <tr key={c.id} className="border-t">
             <td className="border p-2">{c.title}</td>
             <td className="border p-2">{c.active ? 'Yes' : 'No'}</td>
+            <td className="border p-2">
+              <button
+                onClick={() => updateActive(c.id, !c.active)}
+                className={`px-2 ${c.active ? 'bg-red-500' : 'bg-green-500'} text-white`}
+              >
+                {c.active ? 'Deactivate' : 'Activate'}
+              </button>
+            </td>
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
- allow admins to activate or deactivate a challenge directly from the dashboard

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f71c9339883239e3d2667df063d20