### PR TITLE
Remove coin increment from admin actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ npm run dev
 
 1. Sign in with admin email.
 2. Pending submissions appear in a table ordered by `created_at`.
-3. Choose **Accept** → status flips to `approved` and `increment_coins()` fires.
+3. Choose **Accept** → status flips to `approved`.
 4. Choose **Decline** → status flips to `rejected`; player may re‑submit.
 
 ## 9 Player Workflow

--- a/src/components/AdminTable.jsx
+++ b/src/components/AdminTable.jsx
@@ -44,9 +44,6 @@ export default function AdminTable() {
 
   async function updateStatus(id, status) {
     await supabase.from('submissions').update({ status }).eq('id', id);
-    if (status === 'approved') {
-      await supabase.rpc('increment_coins', { p_user: submissions.find((s) => s.id === id).user_id });
-    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- stop calling `increment_coins` when an admin approves submissions
- update admin workflow docs to match

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f746be6348323a76c5f7543dfe0d7