### PR TITLE
Add compressed previews with download option

### DIFF
--- a/src/components/FullScreenImage.jsx
+++ b/src/components/FullScreenImage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 
-export default function FullScreenImage({ src, alt = '', onClose }) {
+export default function FullScreenImage({ src, alt = '', onClose, downloadUrl }) {
   const getOrientation = () =>
     window.innerHeight >= window.innerWidth ? 'portrait' : 'landscape';
   const [orientation, setOrientation] = useState(getOrientation());
@@ -33,6 +33,16 @@ export default function FullScreenImage({ src, alt = '', onClose }) {
           orientation === 'portrait' ? 'max-h-screen' : 'max-w-screen'
         }`}
       />
+      {downloadUrl && (
+        <a
+          href={downloadUrl}
+          download
+          onClick={(e) => e.stopPropagation()}
+          className="absolute top-2 right-2 bg-white text-black px-2 py-1 rounded shadow"
+        >
+          Download
+        </a>
+      )}
     </div>
   );
 

--- a/src/utils/compressImage.js
+++ b/src/utils/compressImage.js
@@ -1,0 +1,29 @@
+export async function compressImage(file, maxBytes = 200000, mime = 'image/jpeg') {
+  const img = await new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const image = new Image();
+    image.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(image);
+    };
+    image.onerror = (e) => {
+      URL.revokeObjectURL(url);
+      reject(e);
+    };
+    image.src = url;
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+
+  let quality = 0.9;
+  let blob = await new Promise((r) => canvas.toBlob(r, mime, quality));
+  while (blob && blob.size > maxBytes && quality > 0.1) {
+    quality -= 0.1;
+    blob = await new Promise((r) => canvas.toBlob(r, mime, quality));
+  }
+  return new File([blob], file.name, { type: mime });
+}


### PR DESCRIPTION
## Summary
- add `compressImage` utility to shrink photos to ~0.2MB
- store compressed previews on upload and save path in `photo_preview`
- update admin/user views to use preview images
- provide download button for full images in full‑screen viewer

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f788b58c88323bb31558943184a06