### PR TITLE
Add fun challenge header

### DIFF
--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -130,6 +130,9 @@ export default function Hunt() {
           Go to Admin Panel
         </button>
       )}
+      <h1 className="text-2xl text-center mb-2">
+        Ready, set, snap! Complete 10 photo challenges to unlock your reward.
+      </h1>
       {challenges.map((c) => {
         const status = challengeStatus[c.id];
         let rowClass = 'bg-amber-100';


### PR DESCRIPTION
## Summary
- add a short message on the hunt page about completing ten photo challenges

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f74d74f4883239b90de67b0d2a7d3