### PR TITLE
Update hunt header with approved challenge count

### DIFF
--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -125,6 +125,10 @@ export default function Hunt() {
     return () => supabase.removeChannel(channel);
   }, []);
 
+  const approvedCount = Object.values(challengeStatus).filter(
+    (status) => status === 'approved'
+  ).length;
+
   if (!user) {
     return (
       <div className="p-4">
@@ -144,7 +148,7 @@ export default function Hunt() {
         </button>
       )}
       <h1 className="text-2xl text-center mb-2">
-        Ready, set, snap! Complete 10 photo challenges to unlock your reward.
+        {`Ready, set, snap! ${approvedCount}/10 photo challenges approved.`}
       </h1>
       {challenges.map((c) => {
         const status = challengeStatus[c.id];


### PR DESCRIPTION
## Summary
- display how many photo challenges have been approved

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7c7dcf08832394ee308fe0f07701