### PR TITLE
Add grouped admin view

### DIFF
--- a/src/components/AdminTable.jsx
+++ b/src/components/AdminTable.jsx
@@ -4,7 +4,7 @@ import FullScreenImage from './FullScreenImage';
 import CommentModal from './CommentModal';
 
 export default function AdminTable() {
-  const [submissions, setSubmissions] = useState([]);
+  const [grouped, setGrouped] = useState({});
   const [previewUrls, setPreviewUrls] = useState({});
   const [downloadUrls, setDownloadUrls] = useState({});
   const [viewer, setViewer] = useState(null); // {preview, download}
@@ -25,24 +25,35 @@ export default function AdminTable() {
   async function load() {
     const { data } = await supabase
       .from('submissions')
-      .select('id, status, comment, photo_url, photo_preview, challenge_id, user_id, created_at')
-      .order('created_at');
-    setSubmissions(data || []);
+      .select(
+        'id, status, comment, photo_url, photo_preview, created_at, user_id, challenge_id(id,title)'
+      )
+      .order('created_at', { ascending: false });
+    const groups = {};
     if (data) {
       const previews = {};
       const fulls = {};
+      data.forEach((s) => {
+        const chId = s.challenge_id?.id || s.challenge_id;
+        const title = s.challenge_id?.title || s.challenge_id;
+        if (!groups[chId]) {
+          groups[chId] = { title, submissions: [], seen: new Set() };
+        }
+        const isLatest = !groups[chId].seen.has(s.user_id);
+        if (isLatest) groups[chId].seen.add(s.user_id);
+        groups[chId].submissions.push({ ...s, isLatest });
+      });
+
       await Promise.all(
         data.map(async (s) => {
           if (s.photo_preview) {
-            const { data: url } = await supabase
-              .storage
+            const { data: url } = await supabase.storage
               .from('photos')
               .createSignedUrl(s.photo_preview, 60 * 60);
             previews[s.id] = url?.signedUrl;
           }
           if (s.photo_url) {
-            const { data: url } = await supabase
-              .storage
+            const { data: url } = await supabase.storage
               .from('photos')
               .createSignedUrl(s.photo_url, 60 * 60);
             fulls[s.id] = url?.signedUrl;
@@ -52,6 +63,7 @@ export default function AdminTable() {
       setPreviewUrls(previews);
       setDownloadUrls(fulls);
     }
+    setGrouped(groups);
   }
 
   async function updateStatus(id, status, comment) {
@@ -62,37 +74,66 @@ export default function AdminTable() {
   }
 
   return (
-    <div className="relative">
-      <table className="w-full border-collapse">
-      <thead>
-        <tr>
-          <th className="border p-2">Photo</th>
-          <th className="border p-2">Status</th>
-          <th className="border p-2">Comment</th>
-          <th className="border p-2">Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        {submissions.map((s) => (
-          <tr key={s.id} className="border-t">
-            <td className="border p-2">
-              <img
-                src={previewUrls[s.id]}
-                alt="submission"
-                className="h-20 cursor-pointer"
-                onClick={() => setViewer({ preview: previewUrls[s.id], download: downloadUrls[s.id] })}
-              />
-            </td>
-            <td className="border p-2">{s.status}</td>
-            <td className="border p-2 whitespace-pre-wrap">{s.comment}</td>
-            <td className="border p-2">
-              <button onClick={() => setPendingAction({ id: s.id, status: 'approved' })} className="bg-green-500 text-white px-2 mr-1">Accept</button>
-              <button onClick={() => setPendingAction({ id: s.id, status: 'rejected' })} className="bg-red-500 text-white px-2">Reject</button>
-            </td>
-          </tr>
-        ))}
-      </tbody>
-      </table>
+    <div className="relative space-y-6">
+      {Object.entries(grouped).map(([chId, group]) => (
+        <div key={chId}>
+          <h2 className="font-bold mb-2">{group.title}</h2>
+          <table className="w-full border-collapse mb-4">
+            <thead>
+              <tr>
+                <th className="border p-2">User</th>
+                <th className="border p-2">Photo</th>
+                <th className="border p-2">Status</th>
+                <th className="border p-2">Comment</th>
+                <th className="border p-2">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {group.submissions.map((s) => (
+                <tr key={s.id} className="border-t">
+                  <td className="border p-2 text-xs break-all">{s.user_id}</td>
+                  <td className="border p-2">
+                    <img
+                      src={previewUrls[s.id]}
+                      alt="submission"
+                      className="h-20 cursor-pointer"
+                      onClick={() =>
+                        setViewer({ preview: previewUrls[s.id], download: downloadUrls[s.id] })
+                      }
+                    />
+                  </td>
+                  <td className="border p-2">{s.status}</td>
+                  <td className="border p-2 whitespace-pre-wrap">{s.comment}</td>
+                  <td className="border p-2">
+                    {s.isLatest ? (
+                      <>
+                        <button
+                          onClick={() =>
+                            setPendingAction({ id: s.id, status: 'approved' })
+                          }
+                          className="bg-green-500 text-white px-2 mr-1"
+                        >
+                          Accept
+                        </button>
+                        <button
+                          onClick={() =>
+                            setPendingAction({ id: s.id, status: 'rejected' })
+                          }
+                          className="bg-red-500 text-white px-2"
+                        >
+                          Reject
+                        </button>
+                      </>
+                    ) : (
+                      <span className="text-gray-500">-</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
       {viewer && (
         <FullScreenImage
           src={viewer.preview}
@@ -113,3 +154,4 @@ export default function AdminTable() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- show submissions grouped by challenge in AdminTable
- display user id with each submission
- only allow actions on the latest submission per user

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f7e7655e08323a254b2f7738dc969