### PR TITLE
Enhance instructions for flexible play

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A lightweight React/Vite web app that lets players submit photo proof for each s
 
 This repository contains a minimal MVP implementation located in the src folder.
 
+To play, sign in and pick any photo challenge to start. Expand a challenge card
+to read its description and hint, then upload your own photo matching the
+example. Once your shot is approved you earn a coin — the challenges can be
+completed in any order.
+
 ---
 
 ## 1 Features
@@ -190,9 +195,9 @@ npm run dev
 ## 9 Player Workflow
 
 1. Sign in with your email and password.
-2. Earliest unlocked challenge shows an **Upload** input.
-3. After upload, card turns yellow (pending). When admin approves, card turns green and the next challenge unlocks.
-4. View a table of your submitted photos with their current approval status below the challenges.
+2. Choose any challenge; each card shows an **Upload** input if you haven't submitted yet.
+3. After upload, the card turns yellow while pending. Once approved it turns green and you earn a coin.
+4. Repeat for the remaining challenges in any order. A table below lists your submissions and their status.
 
 ---
 

--- a/src/pages/Hunt.jsx
+++ b/src/pages/Hunt.jsx
@@ -157,6 +157,11 @@ export default function Hunt() {
       <h1 className="text-2xl text-center mb-2">
         {`Ready, set, snap! ${approvedCount}/10 photo challenges approved.`}
       </h1>
+      <p className="text-center mb-4">
+        Tap a card to read its instructions and view the sample image. Upload
+        your own photo to complete the task &mdash; challenges can be tackled in
+        any order and each approved shot earns a coin.
+      </p>
       {challenges.map((c) => {
         const status = challengeStatus[c.id];
         let rowClass = 'bg-amber-100';


### PR DESCRIPTION
## Summary
- clarify that photo challenges can be done in any order in README
- adjust player workflow steps accordingly
- tweak Hunt page instructions to match

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f82c605bc83239c1f82024ad80726