### PR TITLE
Add Google sign-in support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ completed in any order.
 ## 1 Features
 
 - **Email/password authentication** with browser password-manager prompts
+- **Optional Google sign-in** once enabled in Supabase
 - **Role‑based access control** enforced by Supabase Row Level Security
 - **Image uploads** stored privately in Supabase Storage
 - **Real‑time updates**: players see status changes instantly

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -10,6 +10,18 @@ export default function Login() {
   const [errorMsg, setErrorMsg] = useState('');
   const navigate = useNavigate();
 
+  async function handleGoogleLogin() {
+    setErrorMsg('');
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({ provider: 'google' });
+      if (error) {
+        setErrorMsg(error.message || 'Authentication failed');
+      }
+    } catch (err) {
+      setErrorMsg('Server error. Check configuration and network.');
+    }
+  }
+
   useEffect(() => {
     let subscription;
     async function checkSession() {
@@ -117,6 +129,15 @@ export default function Login() {
               className="underline"
             >
               {mode === 'login' ? 'Need an account?' : 'Have an account?'}
+            </button>
+          </div>
+          <div className="flex justify-center mt-2">
+            <button
+              type="button"
+              onClick={handleGoogleLogin}
+              className="bg-red-600 text-white px-4 py-2 rounded"
+            >
+              Sign in with Google
             </button>
           </div>
           {errorMsg && <p className="text-red-600">{errorMsg}</p>}


### PR DESCRIPTION
## Summary
- add Google OAuth option to Login page
- document optional Google sign-in in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fa6bc3d248323a5b6f4b554246f5b