### PR TITLE
Fix Google OAuth redirect

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -26,7 +26,7 @@ export default function Login() {
     let subscription;
     async function initSession() {
       try {
-        const { data } = await supabase.auth.getSessionFromUrl();
+        const { data } = await supabase.auth.exchangeCodeForSession(window.location.href);
         if (data?.session) {
           navigate('/hunt');
           return;


### PR DESCRIPTION
## Summary
- handle OAuth redirect with `exchangeCodeForSession`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685faabc98e08323978f4105d79057d8