### PR TITLE
Fix Google login on Netlify by redirecting back to /login

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+  force = false

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -16,7 +16,8 @@ export default function Login() {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: window.location.origin + '/hunt',
+        // return to /login so we can exchange the OAuth code before navigating
+        redirectTo: window.location.origin + '/login',
       },
     });
     if (error) {


### PR DESCRIPTION
## Summary
- change Google OAuth redirect to point back to `/login`

This ensures Supabase can exchange the OAuth code on the login page before navigating to `/hunt`.

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686020ca47088323822b4309b9ad4926